### PR TITLE
Split cli and lib files

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -1,0 +1,10 @@
+#! /usr/bin/env node
+
+'use strict'
+
+const { pinoToEcs } = require('../lib')
+
+/* istanbul ignore next */
+if (require.main === module) {
+  pinoToEcs()
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,3 @@
-#! /usr/bin/env node
-
-'use strict'
-
 const stringify = require('fast-safe-stringify')
 const { Transform, pipeline } = require('readable-stream')
 const split = require('split2')
@@ -199,11 +195,6 @@ function toEcs (chunk) {
   }
 
   return log
-}
-
-/* istanbul ignore next */
-if (require.main === module) {
-  pinoToEcs()
 }
 
 module.exports = toEcs

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "pino-to-ecs",
   "version": "0.2.0",
   "description": "Convert Pino logs to Elastic Common Schema",
-  "main": "index.js",
+  "main": "./lib/index.js",
   "bin": {
-    "pino-to-ecs": "./index.js"
+    "pino-to-ecs": "./cli/index.js"
   },
   "scripts": {
     "lint": "standard",

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const Pino = require('pino')
 const { Transform } = require('readable-stream')
 const split = require('split2')
-const toEcs = require('./index')
+const toEcs = require('./lib')
 const { pinoToEcs } = toEcs
 
 test('toEcs', t => {


### PR DESCRIPTION
Importing this library into a project with a bundler (webpack) needs to use shebang-loader in order to remove shebang for node env.